### PR TITLE
Fix Checker Background and set Width to 740px

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 Gemfile.lock
 *.gem
+.jekyll-cache/

--- a/_sass/jekyll-theme-modernist.scss
+++ b/_sass/jekyll-theme-modernist.scss
@@ -4,6 +4,7 @@
 html {
   background:#6C7989;
   background: #6C7989 linear_gradient(#6C7989, #434B55) fixed;
+  height: 100%;
 }
 
 body {
@@ -12,7 +13,8 @@ body {
   font:14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:#555;
   font-weight:300;
-  background:inline-image('checker.png') fixed;
+  background:url('../images/checker.png') fixed;
+  min-height: calc(100% - 100px);
 }
 
 .wrapper {

--- a/_sass/jekyll-theme-modernist.scss
+++ b/_sass/jekyll-theme-modernist.scss
@@ -18,7 +18,7 @@ body {
 }
 
 .wrapper {
-  width:640px;
+  width:740px;
   margin:0 auto;
   background:#DEDEDE;
   border-radius: 8px;


### PR DESCRIPTION
This PR fixes the checker background. The height and min-height values make sure that the background will reach the bottom of the viewport even if the page content does not.

It also widens the page to 740px. 640 looks very narrow on modern displays that are at minimum 1366px wide. I chose 740 because that's the point where the css would change to a mobile layout. This protects any displays that might be between 740 and some higher value from side-scrolling.