### PR TITLE
Add _sass/modernist.scss to allow importing with theme name while using jekyll-remote-theme

### DIFF
--- a/_sass/modernist.scss
+++ b/_sass/modernist.scss
@@ -1,0 +1,4 @@
+// Placeholder file. If your site uses
+//     @import "{{ site.theme }}";
+// Then using this theme with jekyll-remote-theme will work fine.
+@import "jekyll-theme-modernist";


### PR DESCRIPTION
Allows use of `@import {{site.theme}}` when you have `remote_theme: pages-theme/modernist@v0.2.0` in your `_config.yml`.