### PR TITLE
Add "monospace" as a fallback font for pre and code

### DIFF
--- a/_sass/jekyll-theme-modernist.scss
+++ b/_sass/jekyll-theme-modernist.scss
@@ -209,7 +209,7 @@ img {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
   color:#333;
   font-size:12px;
   overflow-x:auto;


### PR DESCRIPTION
Currently, if a client doesn't have any of the fonts listed for `code, pre` available on their system, it uses the browser's default font, which is typically a variable-width font. Unfortunately, this looks terrible.

For example, here is a relevant portion of the demo page viewed under Chrome 103 on my laptop running Lubuntu 22.04, which has none of the specified fonts:

![Before: pre section using variable-width font](https://user-images.githubusercontent.com/275142/177024519-4d8a1942-c73a-400f-8e65-3cb1b7a050cb.png)

This PR adds `monospace` as a final option, which will at least allow browsers to select an available monospace font for those elements. Here is the same section, on the same browser and laptop, after the change:

![After: pre section using monospace font](https://user-images.githubusercontent.com/275142/177024560-d05ca84a-464a-4fdb-a451-af1dea56b2f4.png)